### PR TITLE
Slim CLAUDE.md to gotchas, move architecture to docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,75 +1,18 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Python script that builds this repo's profile README.md from HN favorites, LinkAce links, GitHub stars, and blog posts. Full architecture: `docs/ARCHITECTURE.md`.
 
-## Project Overview
+## Commands
 
-This is a Python-based GitHub profile README generator that automatically updates the main README.md file with dynamic content from various sources:
-- Hacker News favorites (synced to Link Ace with "hackernews" tag)
-- Recent links from Link Ace (personal bookmark manager)
-- GitHub starred repositories
-- Blog posts from pgmac.net.au RSS feed
-
-The script first syncs HN favorites to Link Ace, then builds the README from template files in `src/`. This process runs automatically on a schedule via GitHub Actions.
-
-## Development Commands
-
-### Setup
 ```bash
-# Create and activate virtual environment (recommended)
-python -m venv .venv
-source .venv/bin/activate  # On macOS/Linux
-
-# Install dependencies
-python -m pip install --upgrade pip
+python -m venv .venv && source .venv/bin/activate
 pip install -r src/requirements.txt
+PGLINKS_KEY=<key> python src/update.py
 ```
 
-### Build README
-```bash
-# Build README.md (requires environment variables)
-python src/update.py
+## Gotchas
 
-# Required environment variables:
-# - PGLINKS_KEY: API key for Link Ace instance
-```
-
-## Architecture
-
-### Core Components
-
-**src/update.py** (main script):
-- `fetch_hn_favorites()`: Scrapes HN favorites page using BeautifulSoup
-- `add_link_to_linkace()`: Adds a link to Link Ace via POST API, handles duplicates
-- `sync_hn_favorites_to_linkace()`: Syncs top 10 HN favorites to Link Ace with "hackernews" tag
-- `fetch_link_ace_links()`: Fetches newest public links from Link Ace API (visibility=1 only)
-- `fetch_github_stars()`: Retrieves starred GitHub repositories via GitHub API
-- `fetch_blog_posts()`: Parses blog RSS feed, filtering out "Last-Week" tagged posts
-- `format_*_section()`: Functions that format fetched data into README sections
-- `main()`: Orchestrates HN sync first, then README build by fetching data, formatting sections, and writing output
-
-**src/HEADER.md**: Static header content with personal introduction table
-
-**src/FOOTER.md**: Static footer content (currently empty)
-
-**src/requirements.txt**: Python dependencies (beautifulsoup4, feedparser, requests, urllib3) with security pins from Snyk
-
-### GitHub Actions Workflow
-
-`.github/workflows/build.yml`:
-- Runs on push to master, manual dispatch, and scheduled at 02:00, 08:00, 14:00, 20:00 UTC daily
-- Uses self-hosted runner
-- Python 3.8 runtime
-- Auto-commits changes if README.md is modified
-- Requires secret: PGLINKS_KEY
-
-## Key Implementation Notes
-
-- HN favorites sync runs first and adds new favorites to Link Ace with "hackernews" tag
-- Duplicate URLs are detected via 422 status code and "url has already been taken" error message
-- Only public links (visibility=1) from Link Ace are displayed in the README
-- The script fetches external data from multiple APIs without caching, so runtime depends on API response times
-- BeautifulSoup is used to parse HN favorites HTML (no official API available)
-- Error handling catches and logs failures but continues execution
-- No tests are present in this repository
-- The workflow uses `git diff --quiet` to detect changes before committing
+- HN sync must run before the README build — `main()` order matters, not just independent steps
+- LinkAce duplicate detection relies on parsing a 422 status + specific error string, not a documented API contract
+- Only `visibility=1` LinkAce links are shown
+- No tests in this repo

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,16 @@
+# Architecture
+
+GitHub profile README generator. `.github/workflows/build.yml` runs on push to master, manual dispatch, and a 4x/day schedule (self-hosted runner), auto-committing `README.md` if changed.
+
+## Flow
+
+1. `sync_hn_favorites_to_linkace()` — scrapes the HN favorites page (BeautifulSoup, no official API), adds top 10 to LinkAce with the `hackernews` tag
+2. `fetch_link_ace_links()` / `fetch_github_stars()` / `fetch_blog_posts()` — pull data for the README sections
+3. `format_*_section()` — render each into markdown
+4. `main()` writes the result to `README.md`
+
+## Files
+
+- `src/update.py` — the script above
+- `src/HEADER.md` / `src/FOOTER.md` — static wrapper content
+- `src/requirements.txt` — deps with Snyk security pins


### PR DESCRIPTION
## Summary

- CLAUDE.md cut from 75L to gotchas + non-discoverable commands only
- Function-by-function architecture moved to new `docs/ARCHITECTURE.md`

Part of the wider Claude Code docs cleanup: pgmac-net/homelabia#151

## Test plan

- [ ] `docs/ARCHITECTURE.md` renders correctly and matches current `src/update.py` behaviour
- [ ] Nothing load-bearing was dropped from the old CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgbGfmY1Z3BopzDdsmkY52